### PR TITLE
Move editor views to side panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,17 +50,21 @@
     .skill-btn { border:1px solid #2b2b36; border-radius:10px; padding:8px; background:#14141c; color:#eaeaf0; cursor:pointer; text-align:center; font-size:12px; user-select:none; }
     .skill-btn.active { box-shadow: 0 0 12px #66d1ff; border-color:#66d1ff; }
 
-    /* Zentrales Overlay (Editoren) – deckt die Arena-Fläche ab */
+    /* Seitenpanel für Editoren */
     #center-ui {
-      position:absolute; z-index:25; /* über Canvas, unter Header/Panels */
-      /* Position/Größe werden von main.js exakt gesetzt, damit es mit der Arena deckungsgleich ist */
-      background: rgba(10,10,16,.6);
-      border: 1px solid #2b2b36;
-      border-radius: 10px;
-      overflow: auto;
-      display: none; /* hidden by default */
+      position:absolute;
+      z-index:25; /* über Canvas, unter Header */
+      top:56px; bottom:16px; right:16px;
+      width:520px;
+      padding:12px;
+      border-radius:12px;
+      background:rgba(18,18,28,.78);
+      border:2px solid #1fb6ff;
+      box-shadow:0 0 0 1px rgba(0,0,0,.25) inset;
+      overflow:auto;
+      display:none; /* hidden by default */
     }
-    .center-view { display:none; padding:12px; }
+    .center-view { display:none; }
     .center-view.active { display:block; }
     .center-grid { display:grid; grid-template-columns: 1fr 1fr; gap:12px; }
     .section { border:1px solid #2b2b36; border-radius:10px; padding:10px; background:rgba(20,20,30,.65); }

--- a/js/main.js
+++ b/js/main.js
@@ -60,20 +60,6 @@
     scene: [ Scenes.BootScene, Scenes.PreloadScene, Scenes.FightScene ]
   };
 
-  // ----- Layout Konstanten (mit FightScene synchron) -----
-  const GAME_W=1280, GAME_H=720, HEADER_H=56, SIDE_W=260, MARGIN=16, LOG_H=140;
-  function computeArenaRect(){
-    const leftBlock  = MARGIN + SIDE_W + MARGIN;
-    const rightBlock = MARGIN + SIDE_W + MARGIN;
-    const topBlock   = HEADER_H + MARGIN;
-    const bottomBlock= MARGIN + LOG_H + MARGIN;
-    const w = GAME_W - (leftBlock + rightBlock);
-    const h = GAME_H - (topBlock + bottomBlock);
-    const x = leftBlock + w/2;
-    const y = topBlock + h/2;
-    return { x, y, w, h, top:topBlock, left:leftBlock };
-  }
-
   // ----- UI helpers -----
   function populateCharacterSelects(){
     const p1sel = document.getElementById('p1char');
@@ -101,6 +87,8 @@
     document.getElementById(id)?.classList.add('active');
 
     const center = document.getElementById('center-ui');
+    const leftPanel  = document.getElementById('ui-left');
+    const rightPanel = document.getElementById('ui-right');
     const views = {
       sim: document.getElementById('center-sim'), // nicht vorhanden – nur der Vollständigkeit
       story: document.getElementById('center-story'),
@@ -112,9 +100,13 @@
 
     if (id === 'tab-sim'){
       center.style.display = 'none';
+      leftPanel.style.display  = 'block';
+      rightPanel.style.display = 'block';
       window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'simulator' }}));
     } else {
       center.style.display = 'block';
+      leftPanel.style.display  = 'none';
+      rightPanel.style.display = 'none';
       let mode = 'story';
       if (id==='tab-char'){ mode='char_creator'; views.char.classList.add('active'); startCharCreatorPreviewFromSelection(); }
       if (id==='tab-skill'){ mode='skill_creator'; views.skill.classList.add('active'); }
@@ -170,15 +162,6 @@
   }
 
   // ----- Center-UI Position exakt über Arena setzen -----
-  function placeCenterUI(){
-    const A = computeArenaRect();
-    const ct = document.getElementById('center-ui');
-    ct.style.left   = `${A.left}px`;
-    ct.style.top    = `${A.top}px`;
-    ct.style.width  = `${A.w}px`;
-    ct.style.height = `${A.h}px`;
-  }
-
   // ----- Char Creator: State & Live-Preview -----
   let ccState = null; // aktueller Entwurf
 
@@ -351,10 +334,9 @@
     populateCharacterSelects();
     bindHeader();
     setupSkillButtons();
-    bindCharCreatorCenter();
-    placeCenterUI();
+      bindCharCreatorCenter();
 
-    // Start Game
+      // Start Game
     new Phaser.Game(config);
 
     // Auto-Start


### PR DESCRIPTION
## Summary
- Style central editor container as right-hand panel so the arena remains fully visible.
- Hide player panels when an editor is active and display chosen editor view inside the side panel.
- Simplify main script by removing arena sizing helpers no longer needed.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b605ee80dc8323aa45e8dffcde17fa