### PR TITLE
feat: show character creator modules on left panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,21 +93,47 @@
 
   <!-- SEITENPANELS -->
   <div id="ui-left" class="panel">
-    <h2>Panel 1 • Spieler 1 (KI)</h2>
-    <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
-    <div class="row"><label for="p1ai">Profil</label>
-      <select id="p1ai">
-        <option value="aggressive">aggressiv</option>
-        <option value="defensive">defensiv</option>
-        <option value="random">random</option>
-      </select>
+    <div id="ui-left-sim">
+      <h2>Panel 1 • Spieler 1 (KI)</h2>
+      <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
+      <div class="row"><label for="p1ai">Profil</label>
+        <select id="p1ai">
+          <option value="aggressive">aggressiv</option>
+          <option value="defensive">defensiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
+          <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
+          <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
+          <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+        </div>
+      </div>
     </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
-        <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
-        <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
-        <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+    <div id="ui-left-char" style="display:none;">
+      <h2>Char Creator</h2>
+      <div class="center-grid">
+        <div class="section">
+          <h3>Charakter wählen / laden</h3>
+          <div class="row"><label>Vorlage</label><select id="cc-load"></select></div>
+          <div class="row-inline">
+            <button id="cc-new">Neu</button>
+            <button id="cc-duplicate">Duplizieren</button>
+            <button id="cc-delete">Löschen</button>
+          </div>
+        </div>
+        <div class="section">
+          <h3>Aktionen</h3>
+          <div class="row-inline">
+            <button id="cc-save">Speichern</button>
+            <button id="cc-use-p1">Als P1 nutzen</button>
+            <button id="cc-use-p2">Als P2 nutzen</button>
+            <button id="cc-export">Export JSON</button>
+          </div>
+          <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
+        </div>
       </div>
     </div>
   </div>
@@ -137,28 +163,6 @@
     <!-- Char Creator -->
     <div id="center-char" class="center-view">
       <div class="center-grid">
-        <div class="section">
-          <h3>Charakter wählen / laden</h3>
-          <div class="row"><label>Vorlage</label><select id="cc-load"></select></div>
-          <div class="row-inline">
-            <button id="cc-new">Neu</button>
-            <button id="cc-duplicate">Duplizieren</button>
-            <button id="cc-delete">Löschen</button>
-          </div>
-        </div>
-        <div class="section">
-          <h3>Aktionen</h3>
-          <div class="row-inline">
-            <button id="cc-save">Speichern</button>
-            <button id="cc-use-p1">Als P1 nutzen</button>
-            <button id="cc-use-p2">Als P2 nutzen</button>
-            <button id="cc-export">Export JSON</button>
-          </div>
-          <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
-        </div>
-      </div>
-
-      <div class="center-grid" style="margin-top:12px;">
         <div class="section">
           <h3>Basisdaten</h3>
           <div class="row"><label>Name</label><input id="cc-name" type="text" placeholder="z. B. Nova"/></div>

--- a/js/main.js
+++ b/js/main.js
@@ -89,6 +89,8 @@
     const center = document.getElementById('center-ui');
     const panelL = document.getElementById('ui-left');
     const panelR = document.getElementById('ui-right');
+    const leftSim = document.getElementById('ui-left-sim');
+    const leftChar = document.getElementById('ui-left-char');
     const views = {
       sim: document.getElementById('center-sim'), // nicht vorhanden – nur der Vollständigkeit
       story: document.getElementById('center-story'),
@@ -102,13 +104,25 @@
       center.style.display = 'none';
       panelL.style.display = 'block';
       panelR.style.display = 'block';
+      leftSim.style.display = 'block';
+      leftChar.style.display = 'none';
       window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'simulator' }}));
+    } else if (id === 'tab-char'){
+      center.style.display = 'block';
+      panelL.style.display = 'block';
+      panelR.style.display = 'none';
+      leftSim.style.display = 'none';
+      leftChar.style.display = 'block';
+      views.char.classList.add('active');
+      startCharCreatorPreviewFromSelection();
+      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'char_creator' }}));
     } else {
       center.style.display = 'block';
       panelL.style.display = 'none';
       panelR.style.display = 'none';
+      leftSim.style.display = 'none';
+      leftChar.style.display = 'none';
       let mode = 'story';
-      if (id==='tab-char'){ mode='char_creator'; views.char.classList.add('active'); startCharCreatorPreviewFromSelection(); }
       if (id==='tab-skill'){ mode='skill_creator'; views.skill.classList.add('active'); }
       if (id==='tab-ai')   { mode='ai_creator';    views.ai.classList.add('active'); }
       if (id==='tab-story'){ mode='story';         views.story.classList.add('active'); }


### PR DESCRIPTION
## Summary
- show character selection and action sections on the left panel during character creation
- update tab logic to toggle left panel between simulator and creator modes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b72ca9c184832388f88170c6508ca5