### PR TITLE
Layout anpassen: Arena zentriert halten und Panels umbauen

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,9 +51,7 @@
     .skill-btn.active { box-shadow: 0 0 12px #66d1ff; border-color:#66d1ff; }
 
     /* Editor-Sidepanel */
-    #center-ui { right:16px; display:none; }
-    .center-view { display:none; }
-    .center-view.active { display:block; }
+    /* center-ui removed – views handled inside left/right panels */
     .center-grid { display:flex; flex-direction:column; gap:12px; }
     .section { border:1px solid #2b2b36; border-radius:10px; padding:10px; background:rgba(20,20,30,.65); }
     .section h3 { margin:0 0 8px 0; font-size:14px; color:#9cc9ff; }
@@ -93,113 +91,114 @@
 
   <!-- SEITENPANELS -->
   <div id="ui-left" class="panel">
-    <h2>Panel 1 • Spieler 1 (KI)</h2>
-    <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
-    <div class="row"><label for="p1ai">Profil</label>
-      <select id="p1ai">
-        <option value="aggressive">aggressiv</option>
-        <option value="defensive">defensiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
-        <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
-        <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
-        <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+    <div id="left-sim">
+      <h2>Panel 1 • Spieler 1 (KI)</h2>
+      <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
+      <div class="row"><label for="p1ai">Profil</label>
+        <select id="p1ai">
+          <option value="aggressive">aggressiv</option>
+          <option value="defensive">defensiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
+          <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
+          <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
+          <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+        </div>
       </div>
     </div>
+
+    <div id="left-char" style="display:none;" class="center-grid">
+      <div class="section">
+        <h3>Charakter wählen / laden</h3>
+        <div class="row"><label>Vorlage</label><select id="cc-load"></select></div>
+        <div class="row-inline">
+          <button id="cc-new">Neu</button>
+          <button id="cc-duplicate">Duplizieren</button>
+          <button id="cc-delete">Löschen</button>
+        </div>
+      </div>
+      <div class="section">
+        <h3>Aktionen</h3>
+        <div class="row-inline">
+          <button id="cc-save">Speichern</button>
+          <button id="cc-use-p1">Als P1 nutzen</button>
+          <button id="cc-use-p2">Als P2 nutzen</button>
+          <button id="cc-export">Export JSON</button>
+        </div>
+        <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
+      </div>
+    </div>
+
+    <div id="left-story" style="display:none;"><h2>Story</h2><div class="section"><p>Platzhalter.</p></div></div>
+    <div id="left-skill" style="display:none;"><h2>Skill Creator</h2><div class="section"><p>Platzhalter.</p></div></div>
+    <div id="left-ai" style="display:none;"><h2>KI Creator</h2><div class="section"><p>Platzhalter.</p></div></div>
   </div>
 
   <div id="ui-right" class="panel">
-    <h2>Panel 2 • Spieler 2 (KI)</h2>
-    <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
-    <div class="row"><label for="p2ai">Profil</label>
-      <select id="p2ai">
-        <option value="defensive">defensiv</option>
-        <option value="aggressive">aggressiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
-        <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
-        <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
-        <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
+    <div id="right-sim">
+      <h2>Panel 2 • Spieler 2 (KI)</h2>
+      <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
+      <div class="row"><label for="p2ai">Profil</label>
+        <select id="p2ai">
+          <option value="defensive">defensiv</option>
+          <option value="aggressive">aggressiv</option>
+          <option value="random">random</option>
+        </select>
       </div>
-    </div>
-  </div>
-
-  <!-- Seitenpanel für Editoren -->
-  <div id="center-ui" class="panel">
-    <!-- Char Creator -->
-    <div id="center-char" class="center-view">
-      <div class="center-grid">
-        <div class="section">
-          <h3>Charakter wählen / laden</h3>
-          <div class="row"><label>Vorlage</label><select id="cc-load"></select></div>
-          <div class="row-inline">
-            <button id="cc-new">Neu</button>
-            <button id="cc-duplicate">Duplizieren</button>
-            <button id="cc-delete">Löschen</button>
-          </div>
-        </div>
-        <div class="section">
-          <h3>Aktionen</h3>
-          <div class="row-inline">
-            <button id="cc-save">Speichern</button>
-            <button id="cc-use-p1">Als P1 nutzen</button>
-            <button id="cc-use-p2">Als P2 nutzen</button>
-            <button id="cc-export">Export JSON</button>
-          </div>
-          <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
-        </div>
-      </div>
-
-      <div class="center-grid" style="margin-top:12px;">
-        <div class="section">
-          <h3>Basisdaten</h3>
-          <div class="row"><label>Name</label><input id="cc-name" type="text" placeholder="z. B. Nova"/></div>
-          <div class="row-inline" style="width:100%;">
-            <div style="flex:1">
-              <label>Form</label>
-              <select id="cc-shape"><option value="circle">Kreis</option><option value="square">Quadrat</option><option value="triangle">Dreieck</option></select>
-            </div>
-            <div style="width:120px">
-              <label>Farbe</label><input id="cc-color" type="color" value="#64c8ff"/>
-            </div>
-          </div>
-          <div class="row"><label>Radius</label><input id="cc-radius" type="range" min="14" max="36" value="22"/></div>
-        </div>
-
-        <div class="section">
-          <h3>Stats</h3>
-          <div class="row-inline"><label style="width:100px">HP</label><input id="cc-maxhp" type="number" value="120"/></div>
-          <div class="row-inline"><label style="width:100px">EN</label><input id="cc-maxen" type="number" value="100"/></div>
-          <div class="row-inline"><label style="width:100px">Accel</label><input id="cc-accel" type="number" value="1800"/></div>
-          <div class="row-inline"><label style="width:100px">Speed</label><input id="cc-speed" type="number" value="240"/></div>
-          <div class="row-inline"><label style="width:100px">Dash</label><input id="cc-dash" type="number" value="560"/></div>
-          <div class="row-inline"><label style="width:100px">Friction</label><input id="cc-fric" type="number" step="0.01" value="0.86"/></div>
-        </div>
-
-        <div class="section" style="grid-column: 1 / span 2;">
-          <h3>Skill-Loadout</h3>
-          <div class="row-inline" style="flex-wrap:wrap">
-            <label style="width:auto"><input type="checkbox" id="cc-skill-light" checked/> Light</label>
-            <label style="width:auto"><input type="checkbox" id="cc-skill-heavy" checked/> Heavy</label>
-            <label style="width:auto"><input type="checkbox" id="cc-skill-spin"  checked/> Spin</label>
-            <label style="width:auto"><input type="checkbox" id="cc-skill-heal"  checked/> Heal</label>
-          </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
+          <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
+          <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
+          <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
         </div>
       </div>
     </div>
 
-    <!-- Platzhalter-Ansichten -->
-    <div id="center-story" class="center-view"><div class="section"><h3>Story</h3><p>Platzhalter.</p></div></div>
-    <div id="center-skill" class="center-view"><div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div></div>
-    <div id="center-ai"    class="center-view"><div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div></div>
+    <div id="right-char" style="display:none;" class="center-grid">
+      <div class="section">
+        <h3>Basisdaten</h3>
+        <div class="row"><label>Name</label><input id="cc-name" type="text" placeholder="z. B. Nova"/></div>
+        <div class="row-inline" style="width:100%;">
+          <div style="flex:1">
+            <label>Form</label>
+            <select id="cc-shape"><option value="circle">Kreis</option><option value="square">Quadrat</option><option value="triangle">Dreieck</option></select>
+          </div>
+          <div style="width:120px">
+            <label>Farbe</label><input id="cc-color" type="color" value="#64c8ff"/>
+          </div>
+        </div>
+        <div class="row"><label>Radius</label><input id="cc-radius" type="range" min="14" max="36" value="22"/></div>
+      </div>
+
+      <div class="section">
+        <h3>Stats</h3>
+        <div class="row-inline"><label style="width:100px">HP</label><input id="cc-maxhp" type="number" value="120"/></div>
+        <div class="row-inline"><label style="width:100px">EN</label><input id="cc-maxen" type="number" value="100"/></div>
+        <div class="row-inline"><label style="width:100px">Accel</label><input id="cc-accel" type="number" value="1800"/></div>
+        <div class="row-inline"><label style="width:100px">Speed</label><input id="cc-speed" type="number" value="240"/></div>
+        <div class="row-inline"><label style="width:100px">Dash</label><input id="cc-dash" type="number" value="560"/></div>
+        <div class="row-inline"><label style="width:100px">Friction</label><input id="cc-fric" type="number" step="0.01" value="0.86"/></div>
+      </div>
+
+      <div class="section" style="grid-column: 1 / span 2;">
+        <h3>Skill-Loadout</h3>
+        <div class="row-inline" style="flex-wrap:wrap">
+          <label style="width:auto"><input type="checkbox" id="cc-skill-light" checked/> Light</label>
+          <label style="width:auto"><input type="checkbox" id="cc-skill-heavy" checked/> Heavy</label>
+          <label style="width:auto"><input type="checkbox" id="cc-skill-spin"  checked/> Spin</label>
+          <label style="width:auto"><input type="checkbox" id="cc-skill-heal"  checked/> Heal</label>
+        </div>
+      </div>
+    </div>
+
+    <div id="right-story" style="display:none;" class="center-grid"><div class="section"><h3>Story</h3><p>Platzhalter.</p></div></div>
+    <div id="right-skill" style="display:none;" class="center-grid"><div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div></div>
+    <div id="right-ai"    style="display:none;" class="center-grid"><div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div></div>
   </div>
 
   <div id="footer-note">Run: lokaler Server erforderlich – siehe Anleitung unten.</div>

--- a/js/main.js
+++ b/js/main.js
@@ -86,34 +86,50 @@
     document.querySelectorAll('#ui-header .tab').forEach(b=>b.classList.remove('active'));
     document.getElementById(id)?.classList.add('active');
 
-    const center = document.getElementById('center-ui');
-    const panelL = document.getElementById('ui-left');
-    const panelR = document.getElementById('ui-right');
-    const views = {
-      sim: document.getElementById('center-sim'), // nicht vorhanden – nur der Vollständigkeit
-      story: document.getElementById('center-story'),
-      char: document.getElementById('center-char'),
-      skill: document.getElementById('center-skill'),
-      ai: document.getElementById('center-ai')
+    const LViews = {
+      sim: document.getElementById('left-sim'),
+      char: document.getElementById('left-char'),
+      story: document.getElementById('left-story'),
+      skill: document.getElementById('left-skill'),
+      ai: document.getElementById('left-ai')
     };
-    Object.values(views).forEach(v=>v && v.classList.remove('active'));
+    const RViews = {
+      sim: document.getElementById('right-sim'),
+      char: document.getElementById('right-char'),
+      story: document.getElementById('right-story'),
+      skill: document.getElementById('right-skill'),
+      ai: document.getElementById('right-ai')
+    };
+    Object.values(LViews).forEach(v=>v && (v.style.display='none'));
+    Object.values(RViews).forEach(v=>v && (v.style.display='none'));
 
+    let mode = 'simulator';
     if (id === 'tab-sim'){
-      center.style.display = 'none';
-      panelL.style.display = 'block';
-      panelR.style.display = 'block';
-      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'simulator' }}));
-    } else {
-      center.style.display = 'block';
-      panelL.style.display = 'none';
-      panelR.style.display = 'none';
-      let mode = 'story';
-      if (id==='tab-char'){ mode='char_creator'; views.char.classList.add('active'); startCharCreatorPreviewFromSelection(); }
-      if (id==='tab-skill'){ mode='skill_creator'; views.skill.classList.add('active'); }
-      if (id==='tab-ai')   { mode='ai_creator';    views.ai.classList.add('active'); }
-      if (id==='tab-story'){ mode='story';         views.story.classList.add('active'); }
-      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode }}));
+      LViews.sim.style.display = 'block';
+      RViews.sim.style.display = 'block';
     }
+    if (id === 'tab-char'){
+      mode = 'char_creator';
+      LViews.char.style.display = 'block';
+      RViews.char.style.display = 'block';
+      startCharCreatorPreviewFromSelection();
+    }
+    if (id === 'tab-story'){
+      mode = 'story';
+      LViews.story.style.display = 'block';
+      RViews.story.style.display = 'block';
+    }
+    if (id === 'tab-skill'){
+      mode = 'skill_creator';
+      LViews.skill.style.display = 'block';
+      RViews.skill.style.display = 'block';
+    }
+    if (id === 'tab-ai'){
+      mode = 'ai_creator';
+      LViews.ai.style.display = 'block';
+      RViews.ai.style.display = 'block';
+    }
+    window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode }}));
   }
 
   function flashSkill(side, skill){


### PR DESCRIPTION
## Zusammenfassung
- Entfernt zentrales Editor-Panel und reorganisiert die Ansicht in linke und rechte Panels
- Verschiebt "Charakter wählen / laden" und "Aktionen" in das linke Panel, Basisdaten & Stats in das rechte Panel
- Aktualisiert Tab-Logik, damit beim Wechseln zwischen Menüs die Panels erhalten bleiben und die Arena zentriert bleibt

## Testanweisungen
- `npm test` (schlägt fehl, da kein package.json vorhanden)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b73494d6f48323ae303b31579a8df9