### PR TITLE
Center arena and unify panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 
   <style>
     html, body { margin:0; padding:0; background:#0e0e12; color:#eaeaf0; font-family:system-ui,Segoe UI,Roboto,Inter,Arial,Helvetica,sans-serif; height:100%; overflow:hidden; }
-    #game-root { width:100vw; height:100vh; display:grid; place-items:center; }
+    #game-root { position:absolute; top:56px; left:0; right:0; bottom:0; display:grid; place-items:center; }
 
     /* Top-Leiste */
     #ui-header {
@@ -50,10 +50,6 @@
     .skill-btn { border:1px solid #2b2b36; border-radius:10px; padding:8px; background:#14141c; color:#eaeaf0; cursor:pointer; text-align:center; font-size:12px; user-select:none; }
     .skill-btn.active { box-shadow: 0 0 12px #66d1ff; border-color:#66d1ff; }
 
-    /* Editor-Sidepanel */
-    #center-ui { right:16px; display:none; }
-    .center-view { display:none; }
-    .center-view.active { display:block; }
     .center-grid { display:flex; flex-direction:column; gap:12px; }
     .section { border:1px solid #2b2b36; border-radius:10px; padding:10px; background:rgba(20,20,30,.65); }
     .section h3 { margin:0 0 8px 0; font-size:14px; color:#9cc9ff; }
@@ -93,49 +89,26 @@
 
   <!-- SEITENPANELS -->
   <div id="ui-left" class="panel">
-    <h2>Panel 1 • Spieler 1 (KI)</h2>
-    <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
-    <div class="row"><label for="p1ai">Profil</label>
-      <select id="p1ai">
-        <option value="aggressive">aggressiv</option>
-        <option value="defensive">defensiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
-        <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
-        <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
-        <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+    <div class="panel-view panel-sim">
+      <h2>Panel 1 • Spieler 1 (KI)</h2>
+      <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
+      <div class="row"><label for="p1ai">Profil</label>
+        <select id="p1ai">
+          <option value="aggressive">aggressiv</option>
+          <option value="defensive">defensiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
+          <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
+          <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
+          <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+        </div>
       </div>
     </div>
-  </div>
-
-  <div id="ui-right" class="panel">
-    <h2>Panel 2 • Spieler 2 (KI)</h2>
-    <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
-    <div class="row"><label for="p2ai">Profil</label>
-      <select id="p2ai">
-        <option value="defensive">defensiv</option>
-        <option value="aggressive">aggressiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
-        <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
-        <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
-        <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Seitenpanel für Editoren -->
-  <div id="center-ui" class="panel">
-    <!-- Char Creator -->
-    <div id="center-char" class="center-view">
+    <div class="panel-view panel-char" style="display:none;">
       <div class="center-grid">
         <div class="section">
           <h3>Charakter wählen / laden</h3>
@@ -157,8 +130,40 @@
           <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
         </div>
       </div>
+    </div>
+    <div class="panel-view panel-story" style="display:none;">
+      <div class="section"><h3>Story</h3><p>Platzhalter.</p></div>
+    </div>
+    <div class="panel-view panel-skill" style="display:none;">
+      <div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div>
+    </div>
+    <div class="panel-view panel-ai" style="display:none;">
+      <div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div>
+    </div>
+  </div>
 
-      <div class="center-grid" style="margin-top:12px;">
+  <div id="ui-right" class="panel">
+    <div class="panel-view panel-sim">
+      <h2>Panel 2 • Spieler 2 (KI)</h2>
+      <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
+      <div class="row"><label for="p2ai">Profil</label>
+        <select id="p2ai">
+          <option value="defensive">defensiv</option>
+          <option value="aggressive">aggressiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
+          <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
+          <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
+          <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
+        </div>
+      </div>
+    </div>
+    <div class="panel-view panel-char" style="display:none;">
+      <div class="center-grid">
         <div class="section">
           <h3>Basisdaten</h3>
           <div class="row"><label>Name</label><input id="cc-name" type="text" placeholder="z. B. Nova"/></div>
@@ -173,7 +178,6 @@
           </div>
           <div class="row"><label>Radius</label><input id="cc-radius" type="range" min="14" max="36" value="22"/></div>
         </div>
-
         <div class="section">
           <h3>Stats</h3>
           <div class="row-inline"><label style="width:100px">HP</label><input id="cc-maxhp" type="number" value="120"/></div>
@@ -183,7 +187,6 @@
           <div class="row-inline"><label style="width:100px">Dash</label><input id="cc-dash" type="number" value="560"/></div>
           <div class="row-inline"><label style="width:100px">Friction</label><input id="cc-fric" type="number" step="0.01" value="0.86"/></div>
         </div>
-
         <div class="section" style="grid-column: 1 / span 2;">
           <h3>Skill-Loadout</h3>
           <div class="row-inline" style="flex-wrap:wrap">
@@ -195,11 +198,15 @@
         </div>
       </div>
     </div>
-
-    <!-- Platzhalter-Ansichten -->
-    <div id="center-story" class="center-view"><div class="section"><h3>Story</h3><p>Platzhalter.</p></div></div>
-    <div id="center-skill" class="center-view"><div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div></div>
-    <div id="center-ai"    class="center-view"><div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div></div>
+    <div class="panel-view panel-story" style="display:none;">
+      <div class="section"><h3>Story</h3><p>Platzhalter.</p></div>
+    </div>
+    <div class="panel-view panel-skill" style="display:none;">
+      <div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div>
+    </div>
+    <div class="panel-view panel-ai" style="display:none;">
+      <div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div>
+    </div>
   </div>
 
   <div id="footer-note">Run: lokaler Server erforderlich – siehe Anleitung unten.</div>

--- a/js/main.js
+++ b/js/main.js
@@ -86,34 +86,24 @@
     document.querySelectorAll('#ui-header .tab').forEach(b=>b.classList.remove('active'));
     document.getElementById(id)?.classList.add('active');
 
-    const center = document.getElementById('center-ui');
-    const panelL = document.getElementById('ui-left');
-    const panelR = document.getElementById('ui-right');
-    const views = {
-      sim: document.getElementById('center-sim'), // nicht vorhanden – nur der Vollständigkeit
-      story: document.getElementById('center-story'),
-      char: document.getElementById('center-char'),
-      skill: document.getElementById('center-skill'),
-      ai: document.getElementById('center-ai')
-    };
-    Object.values(views).forEach(v=>v && v.classList.remove('active'));
+    const modeKey = {
+      'tab-sim':'sim',
+      'tab-story':'story',
+      'tab-char':'char',
+      'tab-skill':'skill',
+      'tab-ai':'ai'
+    }[id] || 'story';
 
-    if (id === 'tab-sim'){
-      center.style.display = 'none';
-      panelL.style.display = 'block';
-      panelR.style.display = 'block';
-      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'simulator' }}));
-    } else {
-      center.style.display = 'block';
-      panelL.style.display = 'none';
-      panelR.style.display = 'none';
-      let mode = 'story';
-      if (id==='tab-char'){ mode='char_creator'; views.char.classList.add('active'); startCharCreatorPreviewFromSelection(); }
-      if (id==='tab-skill'){ mode='skill_creator'; views.skill.classList.add('active'); }
-      if (id==='tab-ai')   { mode='ai_creator';    views.ai.classList.add('active'); }
-      if (id==='tab-story'){ mode='story';         views.story.classList.add('active'); }
-      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode }}));
-    }
+    document.querySelectorAll('.panel-view').forEach(v=>v.style.display='none');
+    document.querySelectorAll('.panel-'+modeKey).forEach(v=>v.style.display='block');
+
+    let mode = 'story';
+    if (modeKey==='sim') mode = 'simulator';
+    if (modeKey==='char'){ mode = 'char_creator'; startCharCreatorPreviewFromSelection(); }
+    if (modeKey==='skill') mode = 'skill_creator';
+    if (modeKey==='ai') mode = 'ai_creator';
+
+    window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode }}));
   }
 
   function flashSkill(side, skill){


### PR DESCRIPTION
## Summary
- Keep arena centered below the header by anchoring game root
- Show left and right panels in every top menu tab for a consistent layout
- Move character selection and action controls to the left panel in the character creator
- Update tab switching logic for new panel-based views

## Testing
- ⚠️ `npm test` *(package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b73494d6f48323ae303b31579a8df9