### PR TITLE
Center arena and move Char Creator controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,12 @@
 
   <style>
     html, body { margin:0; padding:0; background:#0e0e12; color:#eaeaf0; font-family:system-ui,Segoe UI,Roboto,Inter,Arial,Helvetica,sans-serif; height:100%; overflow:hidden; }
-    #game-root { width:100vw; height:100vh; display:grid; place-items:center; }
+    #game-root {
+      position:absolute;
+      top:56px; bottom:16px;
+      left:292px; right:292px;
+      display:flex; justify-content:center; align-items:center;
+    }
 
     /* Top-Leiste */
     #ui-header {
@@ -93,49 +98,26 @@
 
   <!-- SEITENPANELS -->
   <div id="ui-left" class="panel">
-    <h2>Panel 1 • Spieler 1 (KI)</h2>
-    <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
-    <div class="row"><label for="p1ai">Profil</label>
-      <select id="p1ai">
-        <option value="aggressive">aggressiv</option>
-        <option value="defensive">defensiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
-        <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
-        <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
-        <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+    <div id="sim-left">
+      <h2>Panel 1 • Spieler 1 (KI)</h2>
+      <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
+      <div class="row"><label for="p1ai">Profil</label>
+        <select id="p1ai">
+          <option value="aggressive">aggressiv</option>
+          <option value="defensive">defensiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
+          <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
+          <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
+          <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+        </div>
       </div>
     </div>
-  </div>
-
-  <div id="ui-right" class="panel">
-    <h2>Panel 2 • Spieler 2 (KI)</h2>
-    <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
-    <div class="row"><label for="p2ai">Profil</label>
-      <select id="p2ai">
-        <option value="defensive">defensiv</option>
-        <option value="aggressive">aggressiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
-        <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
-        <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
-        <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Seitenpanel für Editoren -->
-  <div id="center-ui" class="panel">
-    <!-- Char Creator -->
-    <div id="center-char" class="center-view">
+    <div id="char-left" style="display:none;">
       <div class="center-grid">
         <div class="section">
           <h3>Charakter wählen / laden</h3>
@@ -157,7 +139,30 @@
           <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
         </div>
       </div>
+    </div>
+  </div>
 
+  <div id="ui-right" class="panel">
+    <div id="sim-right">
+      <h2>Panel 2 • Spieler 2 (KI)</h2>
+      <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
+      <div class="row"><label for="p2ai">Profil</label>
+        <select id="p2ai">
+          <option value="defensive">defensiv</option>
+          <option value="aggressive">aggressiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
+          <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
+          <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
+          <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
+        </div>
+      </div>
+    </div>
+    <div id="char-right" style="display:none;">
       <div class="center-grid" style="margin-top:12px;">
         <div class="section">
           <h3>Basisdaten</h3>
@@ -195,7 +200,10 @@
         </div>
       </div>
     </div>
+  </div>
 
+  <!-- Seitenpanel für Editoren -->
+  <div id="center-ui" class="panel">
     <!-- Platzhalter-Ansichten -->
     <div id="center-story" class="center-view"><div class="section"><h3>Story</h3><p>Platzhalter.</p></div></div>
     <div id="center-skill" class="center-view"><div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div></div>

--- a/js/main.js
+++ b/js/main.js
@@ -89,26 +89,42 @@
     const center = document.getElementById('center-ui');
     const panelL = document.getElementById('ui-left');
     const panelR = document.getElementById('ui-right');
+    const simLeft = document.getElementById('sim-left');
+    const simRight = document.getElementById('sim-right');
+    const charLeft = document.getElementById('char-left');
+    const charRight = document.getElementById('char-right');
     const views = {
-      sim: document.getElementById('center-sim'), // nicht vorhanden – nur der Vollständigkeit
       story: document.getElementById('center-story'),
-      char: document.getElementById('center-char'),
       skill: document.getElementById('center-skill'),
       ai: document.getElementById('center-ai')
     };
     Object.values(views).forEach(v=>v && v.classList.remove('active'));
 
+    simLeft.style.display = 'none';
+    simRight.style.display = 'none';
+    charLeft.style.display = 'none';
+    charRight.style.display = 'none';
+
     if (id === 'tab-sim'){
       center.style.display = 'none';
       panelL.style.display = 'block';
       panelR.style.display = 'block';
+      simLeft.style.display = 'block';
+      simRight.style.display = 'block';
       window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'simulator' }}));
+    } else if (id === 'tab-char'){
+      center.style.display = 'none';
+      panelL.style.display = 'block';
+      panelR.style.display = 'block';
+      charLeft.style.display = 'block';
+      charRight.style.display = 'block';
+      startCharCreatorPreviewFromSelection();
+      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'char_creator' }}));
     } else {
       center.style.display = 'block';
       panelL.style.display = 'none';
       panelR.style.display = 'none';
       let mode = 'story';
-      if (id==='tab-char'){ mode='char_creator'; views.char.classList.add('active'); startCharCreatorPreviewFromSelection(); }
       if (id==='tab-skill'){ mode='skill_creator'; views.skill.classList.add('active'); }
       if (id==='tab-ai')   { mode='ai_creator';    views.ai.classList.add('active'); }
       if (id==='tab-story'){ mode='story';         views.story.classList.add('active'); }


### PR DESCRIPTION
## Summary
- Center the Phaser arena between side panels and allow flexible scaling
- Show Char Creator within side panels by moving selection and action controls to the left panel
- Update tab logic to toggle simulator and Char Creator panel content

## Testing
- `node --check js/main.js`
- `python -m py_compile py/ai.py`


------
https://chatgpt.com/codex/tasks/task_e_68b73caffaf88323b1f86fe82f8eeda6