### PR TITLE
Keep arena centered and unify editor layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,13 @@
 
   <style>
     html, body { margin:0; padding:0; background:#0e0e12; color:#eaeaf0; font-family:system-ui,Segoe UI,Roboto,Inter,Arial,Helvetica,sans-serif; height:100%; overflow:hidden; }
-    #game-root { width:100vw; height:100vh; display:grid; place-items:center; }
+    #game-root {
+      position:absolute;
+      top:56px; bottom:16px;
+      left:calc(16px + 260px);
+      right:calc(16px + 260px);
+      display:flex; align-items:center; justify-content:center;
+    }
 
     /* Top-Leiste */
     #ui-header {
@@ -50,10 +56,7 @@
     .skill-btn { border:1px solid #2b2b36; border-radius:10px; padding:8px; background:#14141c; color:#eaeaf0; cursor:pointer; text-align:center; font-size:12px; user-select:none; }
     .skill-btn.active { box-shadow: 0 0 12px #66d1ff; border-color:#66d1ff; }
 
-    /* Editor-Sidepanel */
-    #center-ui { right:16px; display:none; }
-    .center-view { display:none; }
-    .center-view.active { display:block; }
+    /* Editor-Layout */
     .center-grid { display:flex; flex-direction:column; gap:12px; }
     .section { border:1px solid #2b2b36; border-radius:10px; padding:10px; background:rgba(20,20,30,.65); }
     .section h3 { margin:0 0 8px 0; font-size:14px; color:#9cc9ff; }
@@ -87,55 +90,34 @@
       <button id="btn-start">Neustart Match</button>
       <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-ki-brython" checked/> Brython-KI</label>
       <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-hitboxes"/> Hitboxen</label>
-      <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-debug" checked/> Debug</label>
+      <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-debug"/> Debug</label>
     </div>
   </div>
 
   <!-- SEITENPANELS -->
   <div id="ui-left" class="panel">
-    <h2>Panel 1 • Spieler 1 (KI)</h2>
-    <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
-    <div class="row"><label for="p1ai">Profil</label>
-      <select id="p1ai">
-        <option value="aggressive">aggressiv</option>
-        <option value="defensive">defensiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
-        <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
-        <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
-        <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+    <div id="panel-left-sim">
+      <h2>Panel 1 • Spieler 1 (KI)</h2>
+      <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
+      <div class="row"><label for="p1ai">Profil</label>
+        <select id="p1ai">
+          <option value="aggressive">aggressiv</option>
+          <option value="defensive">defensiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
+          <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
+          <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
+          <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div id="ui-right" class="panel">
-    <h2>Panel 2 • Spieler 2 (KI)</h2>
-    <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
-    <div class="row"><label for="p2ai">Profil</label>
-      <select id="p2ai">
-        <option value="defensive">defensiv</option>
-        <option value="aggressive">aggressiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
-        <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
-        <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
-        <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Seitenpanel für Editoren -->
-  <div id="center-ui" class="panel">
-    <!-- Char Creator -->
-    <div id="center-char" class="center-view">
+    <div id="panel-left-char" style="display:none;">
+      <h2>Char Creator</h2>
       <div class="center-grid">
         <div class="section">
           <h3>Charakter wählen / laden</h3>
@@ -157,7 +139,36 @@
           <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
         </div>
       </div>
+    </div>
 
+    <div id="panel-left-story" style="display:none;"><h2>Story</h2><p>Platzhalter.</p></div>
+    <div id="panel-left-skill" style="display:none;"><h2>Skill Creator</h2><p>Platzhalter.</p></div>
+    <div id="panel-left-ai" style="display:none;"><h2>KI Creator</h2><p>Platzhalter.</p></div>
+  </div>
+
+  <div id="ui-right" class="panel">
+    <div id="panel-right-sim">
+      <h2>Panel 2 • Spieler 2 (KI)</h2>
+      <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
+      <div class="row"><label for="p2ai">Profil</label>
+        <select id="p2ai">
+          <option value="defensive">defensiv</option>
+          <option value="aggressive">aggressiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
+          <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
+          <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
+          <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
+        </div>
+      </div>
+    </div>
+
+    <div id="panel-right-char" style="display:none;">
+      <h2>Char Creator</h2>
       <div class="center-grid" style="margin-top:12px;">
         <div class="section">
           <h3>Basisdaten</h3>
@@ -196,10 +207,9 @@
       </div>
     </div>
 
-    <!-- Platzhalter-Ansichten -->
-    <div id="center-story" class="center-view"><div class="section"><h3>Story</h3><p>Platzhalter.</p></div></div>
-    <div id="center-skill" class="center-view"><div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div></div>
-    <div id="center-ai"    class="center-view"><div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div></div>
+    <div id="panel-right-story" style="display:none;"><h2>Story</h2><p>Platzhalter.</p></div>
+    <div id="panel-right-skill" style="display:none;"><h2>Skill Creator</h2><p>Platzhalter.</p></div>
+    <div id="panel-right-ai" style="display:none;"><h2>KI Creator</h2><p>Platzhalter.</p></div>
   </div>
 
   <div id="footer-note">Run: lokaler Server erforderlich – siehe Anleitung unten.</div>

--- a/js/main.js
+++ b/js/main.js
@@ -86,34 +86,51 @@
     document.querySelectorAll('#ui-header .tab').forEach(b=>b.classList.remove('active'));
     document.getElementById(id)?.classList.add('active');
 
-    const center = document.getElementById('center-ui');
-    const panelL = document.getElementById('ui-left');
-    const panelR = document.getElementById('ui-right');
-    const views = {
-      sim: document.getElementById('center-sim'), // nicht vorhanden – nur der Vollständigkeit
-      story: document.getElementById('center-story'),
-      char: document.getElementById('center-char'),
-      skill: document.getElementById('center-skill'),
-      ai: document.getElementById('center-ai')
+    const leftViews = {
+      sim: document.getElementById('panel-left-sim'),
+      story: document.getElementById('panel-left-story'),
+      char: document.getElementById('panel-left-char'),
+      skill: document.getElementById('panel-left-skill'),
+      ai: document.getElementById('panel-left-ai')
     };
-    Object.values(views).forEach(v=>v && v.classList.remove('active'));
+    const rightViews = {
+      sim: document.getElementById('panel-right-sim'),
+      story: document.getElementById('panel-right-story'),
+      char: document.getElementById('panel-right-char'),
+      skill: document.getElementById('panel-right-skill'),
+      ai: document.getElementById('panel-right-ai')
+    };
+    Object.values(leftViews).forEach(v=>v && (v.style.display='none'));
+    Object.values(rightViews).forEach(v=>v && (v.style.display='none'));
 
-    if (id === 'tab-sim'){
-      center.style.display = 'none';
-      panelL.style.display = 'block';
-      panelR.style.display = 'block';
-      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'simulator' }}));
-    } else {
-      center.style.display = 'block';
-      panelL.style.display = 'none';
-      panelR.style.display = 'none';
-      let mode = 'story';
-      if (id==='tab-char'){ mode='char_creator'; views.char.classList.add('active'); startCharCreatorPreviewFromSelection(); }
-      if (id==='tab-skill'){ mode='skill_creator'; views.skill.classList.add('active'); }
-      if (id==='tab-ai')   { mode='ai_creator';    views.ai.classList.add('active'); }
-      if (id==='tab-story'){ mode='story';         views.story.classList.add('active'); }
-      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode }}));
+    let mode = 'simulator';
+    switch(id){
+      case 'tab-story':
+        mode = 'story';
+        leftViews.story.style.display = 'block';
+        rightViews.story.style.display = 'block';
+        break;
+      case 'tab-char':
+        mode = 'char_creator';
+        leftViews.char.style.display = 'block';
+        rightViews.char.style.display = 'block';
+        startCharCreatorPreviewFromSelection();
+        break;
+      case 'tab-skill':
+        mode = 'skill_creator';
+        leftViews.skill.style.display = 'block';
+        rightViews.skill.style.display = 'block';
+        break;
+      case 'tab-ai':
+        mode = 'ai_creator';
+        leftViews.ai.style.display = 'block';
+        rightViews.ai.style.display = 'block';
+        break;
+      default:
+        leftViews.sim.style.display = 'block';
+        rightViews.sim.style.display = 'block';
     }
+    window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode }}));
   }
 
   function flashSkill(side, skill){


### PR DESCRIPTION
## Summary
- Keep the arena centered between side panels and leave debug mode off by default
- Move character selection and action controls into the left panel and split editor content across both panels
- Refactor tab logic so left/right panels persist with placeholders for unfinished sections

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7403cf13083238a3488ce3ec6d245