### PR TITLE
Refactor layout and add draggable HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,14 +50,22 @@
     .skill-btn { border:1px solid #2b2b36; border-radius:10px; padding:8px; background:#14141c; color:#eaeaf0; cursor:pointer; text-align:center; font-size:12px; user-select:none; }
     .skill-btn.active { box-shadow: 0 0 12px #66d1ff; border-color:#66d1ff; }
 
-    /* Editor-Sidepanel */
-    #center-ui { right:16px; display:none; }
-    .center-view { display:none; }
-    .center-view.active { display:block; }
     .center-grid { display:flex; flex-direction:column; gap:12px; }
     .section { border:1px solid #2b2b36; border-radius:10px; padding:10px; background:rgba(20,20,30,.65); }
     .section h3 { margin:0 0 8px 0; font-size:14px; color:#9cc9ff; }
     .row-inline { display:flex; gap:8px; align-items:center; }
+
+    /* HUD-Fenster */
+    #hud-window {
+      position:absolute; top:80px; left:80px; min-width:200px;
+      background:rgba(20,20,30,.9); border:1px solid #2b2b36;
+      border-radius:8px; color:#b9c2ff; z-index:1000; display:none;
+    }
+    #hud-title {
+      background:#0b0b10; cursor:move; padding:4px 8px; font-size:12px;
+      border-bottom:1px solid #2b2b36;
+    }
+    #hud-content { padding:8px; font-size:12px; white-space:pre; }
 
     #footer-note { position:absolute; bottom:10px; left:12px; font-size:12px; opacity:.7; user-select:none; }
   </style>
@@ -87,55 +95,39 @@
       <button id="btn-start">Neustart Match</button>
       <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-ki-brython" checked/> Brython-KI</label>
       <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-hitboxes"/> Hitboxen</label>
-      <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-debug" checked/> Debug</label>
+        <label style="display:flex;gap:6px;align-items:center;"><input type="checkbox" id="toggle-debug"/> Debug</label>
+      </div>
     </div>
+
+  <!-- HUD-Fenster -->
+  <div id="hud-window">
+    <div id="hud-title">Debug HUD</div>
+    <pre id="hud-content"></pre>
   </div>
 
   <!-- SEITENPANELS -->
   <div id="ui-left" class="panel">
-    <h2>Panel 1 • Spieler 1 (KI)</h2>
-    <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
-    <div class="row"><label for="p1ai">Profil</label>
-      <select id="p1ai">
-        <option value="aggressive">aggressiv</option>
-        <option value="defensive">defensiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
-        <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
-        <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
-        <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+    <div id="panel-sim-left">
+      <h2>Panel 1 • Spieler 1 (KI)</h2>
+      <div class="row"><label for="p1char">Charakter</label><select id="p1char"></select></div>
+      <div class="row"><label for="p1ai">Profil</label>
+        <select id="p1ai">
+          <option value="aggressive">aggressiv</option>
+          <option value="defensive">defensiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p1-skill-light"  class="skill-btn" data-side="P1" data-skill="light">Light</div>
+          <div id="p1-skill-heavy"  class="skill-btn" data-side="P1" data-skill="heavy">Heavy</div>
+          <div id="p1-skill-spin"   class="skill-btn" data-side="P1" data-skill="spin">Spin</div>
+          <div id="p1-skill-heal"   class="skill-btn" data-side="P1" data-skill="heal">Heal</div>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div id="ui-right" class="panel">
-    <h2>Panel 2 • Spieler 2 (KI)</h2>
-    <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
-    <div class="row"><label for="p2ai">Profil</label>
-      <select id="p2ai">
-        <option value="defensive">defensiv</option>
-        <option value="aggressive">aggressiv</option>
-        <option value="random">random</option>
-      </select>
-    </div>
-    <div class="row"><label>Skills</label>
-      <div class="skills-grid">
-        <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
-        <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
-        <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
-        <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Seitenpanel für Editoren -->
-  <div id="center-ui" class="panel">
-    <!-- Char Creator -->
-    <div id="center-char" class="center-view">
+    <div id="panel-char-left" style="display:none;">
       <div class="center-grid">
         <div class="section">
           <h3>Charakter wählen / laden</h3>
@@ -157,8 +149,42 @@
           <small>Speichern legt/aktualisiert den Charakter in der Datenbank (auch localStorage). „Nutzen“ startet sofort ein Match.</small>
         </div>
       </div>
+    </div>
 
-      <div class="center-grid" style="margin-top:12px;">
+    <div id="panel-story-left" style="display:none;">
+      <div class="section"><h3>Story</h3><p>Platzhalter.</p></div>
+    </div>
+    <div id="panel-skill-left" style="display:none;">
+      <div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div>
+    </div>
+    <div id="panel-ai-left" style="display:none;">
+      <div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div>
+    </div>
+  </div>
+
+  <div id="ui-right" class="panel">
+    <div id="panel-sim-right">
+      <h2>Panel 2 • Spieler 2 (KI)</h2>
+      <div class="row"><label for="p2char">Charakter</label><select id="p2char"></select></div>
+      <div class="row"><label for="p2ai">Profil</label>
+        <select id="p2ai">
+          <option value="defensive">defensiv</option>
+          <option value="aggressive">aggressiv</option>
+          <option value="random">random</option>
+        </select>
+      </div>
+      <div class="row"><label>Skills</label>
+        <div class="skills-grid">
+          <div id="p2-skill-light"  class="skill-btn" data-side="P2" data-skill="light">Light</div>
+          <div id="p2-skill-heavy"  class="skill-btn" data-side="P2" data-skill="heavy">Heavy</div>
+          <div id="p2-skill-spin"   class="skill-btn" data-side="P2" data-skill="spin">Spin</div>
+          <div id="p2-skill-heal"   class="skill-btn" data-side="P2" data-skill="heal">Heal</div>
+        </div>
+      </div>
+    </div>
+
+    <div id="panel-char-right" style="display:none;">
+      <div class="center-grid">
         <div class="section">
           <h3>Basisdaten</h3>
           <div class="row"><label>Name</label><input id="cc-name" type="text" placeholder="z. B. Nova"/></div>
@@ -196,10 +222,15 @@
       </div>
     </div>
 
-    <!-- Platzhalter-Ansichten -->
-    <div id="center-story" class="center-view"><div class="section"><h3>Story</h3><p>Platzhalter.</p></div></div>
-    <div id="center-skill" class="center-view"><div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div></div>
-    <div id="center-ai"    class="center-view"><div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div></div>
+    <div id="panel-story-right" style="display:none;">
+      <div class="section"><h3>Story</h3><p>Platzhalter.</p></div>
+    </div>
+    <div id="panel-skill-right" style="display:none;">
+      <div class="section"><h3>Skill Creator</h3><p>Platzhalter.</p></div>
+    </div>
+    <div id="panel-ai-right" style="display:none;">
+      <div class="section"><h3>KI Creator</h3><p>Platzhalter.</p></div>
+    </div>
   </div>
 
   <div id="footer-note">Run: lokaler Server erforderlich – siehe Anleitung unten.</div>

--- a/js/main.js
+++ b/js/main.js
@@ -82,39 +82,39 @@
     if (ccLoad && chars[0]) ccLoad.value = chars[0].id;
   }
 
-  function setActiveTab(id){
-    document.querySelectorAll('#ui-header .tab').forEach(b=>b.classList.remove('active'));
-    document.getElementById(id)?.classList.add('active');
+    function setActiveTab(id){
+      document.querySelectorAll('#ui-header .tab').forEach(b=>b.classList.remove('active'));
+      document.getElementById(id)?.classList.add('active');
 
-    const center = document.getElementById('center-ui');
-    const panelL = document.getElementById('ui-left');
-    const panelR = document.getElementById('ui-right');
-    const views = {
-      sim: document.getElementById('center-sim'), // nicht vorhanden – nur der Vollständigkeit
-      story: document.getElementById('center-story'),
-      char: document.getElementById('center-char'),
-      skill: document.getElementById('center-skill'),
-      ai: document.getElementById('center-ai')
-    };
-    Object.values(views).forEach(v=>v && v.classList.remove('active'));
+      // alle Panel-Inhalte verbergen
+      document.querySelectorAll('#ui-left > div').forEach(d=>d.style.display='none');
+      document.querySelectorAll('#ui-right > div').forEach(d=>d.style.display='none');
 
-    if (id === 'tab-sim'){
-      center.style.display = 'none';
-      panelL.style.display = 'block';
-      panelR.style.display = 'block';
-      window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode:'simulator' }}));
-    } else {
-      center.style.display = 'block';
-      panelL.style.display = 'none';
-      panelR.style.display = 'none';
-      let mode = 'story';
-      if (id==='tab-char'){ mode='char_creator'; views.char.classList.add('active'); startCharCreatorPreviewFromSelection(); }
-      if (id==='tab-skill'){ mode='skill_creator'; views.skill.classList.add('active'); }
-      if (id==='tab-ai')   { mode='ai_creator';    views.ai.classList.add('active'); }
-      if (id==='tab-story'){ mode='story';         views.story.classList.add('active'); }
+      let mode = 'simulator';
+      if (id === 'tab-sim'){
+        document.getElementById('panel-sim-left').style.display='block';
+        document.getElementById('panel-sim-right').style.display='block';
+        mode = 'simulator';
+      } else if (id === 'tab-char'){
+        document.getElementById('panel-char-left').style.display='block';
+        document.getElementById('panel-char-right').style.display='block';
+        startCharCreatorPreviewFromSelection();
+        mode = 'char_creator';
+      } else if (id === 'tab-story'){
+        document.getElementById('panel-story-left').style.display='block';
+        document.getElementById('panel-story-right').style.display='block';
+        mode = 'story';
+      } else if (id === 'tab-skill'){
+        document.getElementById('panel-skill-left').style.display='block';
+        document.getElementById('panel-skill-right').style.display='block';
+        mode = 'skill_creator';
+      } else if (id === 'tab-ai'){
+        document.getElementById('panel-ai-left').style.display='block';
+        document.getElementById('panel-ai-right').style.display='block';
+        mode = 'ai_creator';
+      }
       window.dispatchEvent(new CustomEvent('VC_SET_MODE', { detail:{ mode }}));
     }
-  }
 
   function flashSkill(side, skill){
     const id = `${side.toLowerCase()}-skill-${skill}`;
@@ -159,6 +159,22 @@
     document.getElementById('tab-char')?.addEventListener('click', ()=>setActiveTab('tab-char'));
     document.getElementById('tab-skill')?.addEventListener('click', ()=>setActiveTab('tab-skill'));
     document.getElementById('tab-ai')?.addEventListener('click', ()=>setActiveTab('tab-ai'));
+  }
+
+  function initHUDWindow(){
+    const win = document.getElementById('hud-window');
+    const title = document.getElementById('hud-title');
+    if (!win || !title) return;
+    let dragging = false, offX = 0, offY = 0;
+    title.addEventListener('mousedown', e=>{
+      dragging = true;
+      offX = e.clientX - win.offsetLeft;
+      offY = e.clientY - win.offsetTop;
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', up);
+    });
+    function move(e){ if (!dragging) return; win.style.left = (e.clientX - offX) + 'px'; win.style.top = (e.clientY - offY) + 'px'; }
+    function up(){ dragging=false; document.removeEventListener('mousemove', move); document.removeEventListener('mouseup', up); }
   }
 
   // ----- Char Creator: State & Live-Preview -----
@@ -229,7 +245,7 @@
     emitCCUpdate();
   }
 
-  function bindCharCreatorCenter(){
+    function bindCharCreatorUI(){
     // Eingaben -> Realtime Preview
     ['cc-name','cc-shape','cc-color','cc-radius','cc-maxhp','cc-maxen','cc-accel','cc-speed','cc-dash','cc-fric',
      'cc-skill-light','cc-skill-heavy','cc-skill-spin','cc-skill-heal'
@@ -333,7 +349,8 @@
     populateCharacterSelects();
     bindHeader();
     setupSkillButtons();
-    bindCharCreatorCenter();
+    bindCharCreatorUI();
+      initHUDWindow();
 
     // Start Game
     new Phaser.Game(config);

--- a/js/scenes/FightScene.js
+++ b/js/scenes/FightScene.js
@@ -25,7 +25,7 @@
     Extends: Phaser.Scene,
     initialize: function FightScene(){
       Phaser.Scene.call(this, { key: 'FightScene' });
-      this._uiOpts = { showHit:false, showDebug:true, useBrython:true, p1:'aggressive', p2:'defensive', p1CharId:null, p2CharId:null };
+        this._uiOpts = { showHit:false, showDebug:false, useBrython:true, p1:'aggressive', p2:'defensive', p1CharId:null, p2CharId:null };
       this._mode = 'simulator'; // simulator | story | char_creator | skill_creator | ai_creator
       this._paused = false;
       this._ccPreview = null;
@@ -45,8 +45,9 @@
       this._logBuffer = [];
       this._drawLogFrame();
 
-      // HUD
-      this._hud = this.add.text(16, this.scale.height-18, '', { fontSize:12, color:'#b9c2ff' }).setOrigin(0,1).setDepth(1000);
+        // HUD (DOM)
+        this._hudEl = document.getElementById('hud-content');
+        this._hudWin = document.getElementById('hud-window');
 
       // Systeme
       this.hitboxes = new HitboxSystem(this);
@@ -226,14 +227,19 @@
       this._renderHUD();
     },
 
-    _renderHUD: function(){
-      if (!this._uiOpts.showDebug){ this._hud.setText(''); return; }
-      const fps = this.game.loop.actualFps|0;
-      const a = this.fighters[0], b = this.fighters[1];
-      const s1 = a? `${a.id} HP:${a.hp|0}/${a.maxHp} EN:${a.en|0} ${a.state}${a.moveName?`(${a.moveName}:${a.moveFrame})`:''}` : '';
-      const s2 = b? `${b.id} HP:${b.hp|0}/${b.maxHp} EN:${b.en|0} ${b.state}${b.moveName?`(${b.moveName}:${b.moveFrame})`:''}` : '';
-      this._hud.setText(`FPS:${fps}  Mode:${this._mode}  BrythonReady:${window.GameBridge.isBrythonReady()}  Hitstop:${this.feel.hitstopFrames}\n${s1}\n${s2}`);
-    },
+      _renderHUD: function(){
+        if (!this._uiOpts.showDebug){
+          if (this._hudWin) this._hudWin.style.display = 'none';
+          if (this._hudEl) this._hudEl.textContent = '';
+          return;
+        }
+        if (this._hudWin) this._hudWin.style.display = 'block';
+        const fps = this.game.loop.actualFps|0;
+        const a = this.fighters[0], b = this.fighters[1];
+        const s1 = a? `${a.id} HP:${a.hp|0}/${a.maxHp} EN:${a.en|0} ${a.state}${a.moveName?`(${a.moveName}:${a.moveFrame})`:''}` : '';
+        const s2 = b? `${b.id} HP:${b.hp|0}/${b.maxHp} EN:${b.en|0} ${b.state}${b.moveName?`(${b.moveName}:${b.moveFrame})`:''}` : '';
+        if (this._hudEl) this._hudEl.textContent = `FPS:${fps}  Mode:${this._mode}  BrythonReady:${window.GameBridge.isBrythonReady()}  Hitstop:${this.feel.hitstopFrames}\n${s1}\n${s2}`;
+      },
 
     _onSkillUsed: function({fighter, move}){
       const side = fighter.teamId===1?'P1':'P2';


### PR DESCRIPTION
## Summary
- Add floating draggable HUD window and disable debug by default
- Keep side panels visible across modes with tab-specific content
- Move character selection and actions to left panel in character creator

## Testing
- `python -m py_compile py/ai.py`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b749c6c6ec8323835fc7ff9e6ea1a1